### PR TITLE
Allow null values in the ROW/COLUMN values. 

### DIFF
--- a/wicket-pivot/src/main/java/ro/fortsoft/wicket/pivot/tree/TreeHelper.java
+++ b/wicket-pivot/src/main/java/ro/fortsoft/wicket/pivot/tree/TreeHelper.java
@@ -55,7 +55,8 @@ public class TreeHelper {
 	
 	public static Node getChild(Node node, Object value) {
 		for (Node child : node.getChildren()) {
-			if (value.equals(child.getData())) {
+			Object data = child.getData();
+			if (value == data || (value != null && value.equals(data))) {
 				return child;
 			}
 		}


### PR DESCRIPTION
The user might select some nullable numeric fields for grouping (which doesn't really make sense for
grouping) and should not see a NullPointerException in this case.

null-values are treated as equal and sorted first.
