### PR TITLE
RFC: Basic CSV Exporter

### DIFF
--- a/wicket-pivot/src/main/java/ro/fortsoft/wicket/pivot/web/PivotCsvExporter.java
+++ b/wicket-pivot/src/main/java/ro/fortsoft/wicket/pivot/web/PivotCsvExporter.java
@@ -24,21 +24,20 @@ public class PivotCsvExporter {
 		for (RenderRow row : renderModel.getAllRenderRows()) {
 			int col = 0;
 			for (RenderCell cell : row.getRenderCells()) {
-
 				/*
 				 * Check if we currently have a rowspan at this column from the
 				 * parent row. We only support a colspan of 1 at the moment
-				 * hier, if rowspan > 1
+				 * here, if rowspan > 1
 				 */
 				Integer rowSpan = rowSpanMap.get(col);
 				if (rowSpan != null) {
 					rowSpan--;
-					col++;
-					out.append(seperator);
 					if (rowSpan == 0)
 						rowSpanMap.remove(col);
 					else
 						rowSpanMap.put(col, rowSpan);
+					col++;
+					out.append(seperator);
 				}
 
 				/*
@@ -50,17 +49,20 @@ public class PivotCsvExporter {
 				out.append(seperator);
 				if (cell.rowspan > 1)
 					rowSpanMap.put(col, cell.rowspan - 1);
+				col++;
 
 				/*
 				 * We only support colspan _OR_ rowspan. The current PivotTable
 				 * also doesnt have rowspan and colspan at the same time.
 				 */
-				for (int i = 1; i < cell.colspan; i++)
+				for (int i = 1; i < cell.colspan; i++) {
 					out.append(seperator);
-				col++;
+					col++;
+				}
 			}
 			out.append("\n");
 		}
+		out.flush();
 	}
 
 	public void setSeperator(String seperator) {

--- a/wicket-pivot/src/main/java/ro/fortsoft/wicket/pivot/web/PivotPanel.html
+++ b/wicket-pivot/src/main/java/ro/fortsoft/wicket/pivot/web/PivotPanel.html
@@ -26,5 +26,7 @@
 	<div class="row-fluid" style="overflow-x: auto;">    
  		<table wicket:id="pivotTable" class="pivot table table-striped table-bordered table-condensed"></table>
  	</div> 	
+ 	
+ 	<a wicket:id='downloadCSV' href='#' class='btn' target='pivotTableDownload'>Download as CSV</a>
 </wicket:panel>
 </html>

--- a/wicket-pivot/src/main/java/ro/fortsoft/wicket/pivot/web/PivotTableRenderModel.java
+++ b/wicket-pivot/src/main/java/ro/fortsoft/wicket/pivot/web/PivotTableRenderModel.java
@@ -31,7 +31,7 @@ public class PivotTableRenderModel implements Serializable {
 
 		protected RenderCell() {
 		}
-		
+
 		public Object getRawValue() {
 			return value;
 		}
@@ -69,7 +69,8 @@ public class PivotTableRenderModel implements Serializable {
 
 		public HeaderRenderCell(PivotField pivotField) {
 			this.pivotField = pivotField;
-			value = pivotField.getTitle();
+			if (pivotField != null)
+				value = pivotField.getTitle();
 		}
 	}
 


### PR DESCRIPTION
I've made a PivotTableRenderModel based on the PivotTable, and used it to export the whole table as a CSV file.

As I plan to base the PivotTable on the PivotTableRenderModel for the output (to remove the here introduced code duplication), I`ve  created very specialized classes for every type of cell/row to output, so that it is very easy to use in the PivotTable.

I expect PivotTableRenderModel to change future when I adapt the PivotTable to use it.

This pull request is more a discussion request. You can pull if you like, or wait till I "finish" the rest.
- Is the whole approach ok?
- Is the class/method naming ok? Should the exporter be in its own package?
- I would like to implement this exporter for the "real thing", i.e. Excel => Is a dependency on Apache POI (http://poi.apache.org/) ok? Otherwise I`ll try to build some interfaces mechanism, so that I can plugin a Excel exporter.

Thanks.
