### PR TITLE
Upgrade to Wicket 7

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -14,7 +14,7 @@
     <name>Wicket Pivot Demo</name>
         
     <properties>
-        <jetty.version>7.5.0.v20110901</jetty.version>
+        <jetty.version>8.1.16.v20140903</jetty.version>
         <slf4j.version>1.6.4</slf4j.version>
         <log4j.version>1.2.16</log4j.version>
     </properties>
@@ -104,7 +104,7 @@
             <groupId>org.eclipse.jetty.aggregate</groupId>
             <artifactId>jetty-all-server</artifactId>
             <version>${jetty.version}</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <wicket.version>6.12.0</wicket.version>
+        <wicket.version>7.1.0</wicket.version>
     </properties>   
 
     <build>
@@ -53,10 +53,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <optimize>true</optimize>
                 </configuration>
             </plugin>

--- a/wicket-pivot-exporter/pom.xml
+++ b/wicket-pivot-exporter/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>3.7</version>
+			<version>3.13</version>
 		</dependency>
 
 	</dependencies>

--- a/wicket-pivot/src/main/java/ro/fortsoft/wicket/pivot/config/PivotConfig.java
+++ b/wicket-pivot/src/main/java/ro/fortsoft/wicket/pivot/config/PivotConfig.java
@@ -12,15 +12,15 @@
  */
 package ro.fortsoft.wicket.pivot.config;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
 import ro.fortsoft.wicket.pivot.Aggregator;
 import ro.fortsoft.wicket.pivot.FieldCalculation;
 import ro.fortsoft.wicket.pivot.PivotField;
 import ro.fortsoft.wicket.pivot.PivotField.Area;
 import ro.fortsoft.wicket.pivot.PivotModel;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A stored pivot table configuration. The structure of this class and its child
@@ -202,14 +202,14 @@ public class PivotConfig implements Serializable {
 		this.name = name;
 	}
 
-	/**
+	/*
 	 * @internal Only for the serializers
 	 */
 	public PivotConfigField[] getPivotConfigFields() {
 		return pivotConfigFields;
 	}
 
-	/**
+	/*
 	 * @internal Only for the serializers
 	 */
 	public void setPivotConfigFields(PivotConfigField[] pivotConfigFields) {


### PR DESCRIPTION
Upgrading wicket-pivot to wicket 7 is straight forward. Just jetty needs to be upgraded also (because of the Servlet API 3.0 requirement of Wicket 7). 

Also increased the compiler level to Java 7, as this is the minimum for wicket 7.